### PR TITLE
[fix] arabic with arabic numbers getting failed due to latin num

### DIFF
--- a/src/Soap/Requests/SendSMSRequest.php
+++ b/src/Soap/Requests/SendSMSRequest.php
@@ -16,7 +16,7 @@ class SendSMSRequest {
 
     public function __construct($arabic = false) {
         if($arabic) {
-            $this->messageType = "ArabicWithArabicNumbers";
+            $this->messageType = "ArabicWithLatinNumbers";
         }
     }
 }


### PR DESCRIPTION
In the case of SMS content "Arabic with Latin numbers" ooredoo rejected the request. So consider this fix